### PR TITLE
Add markdown plugin from tpope.

### DIFF
--- a/dotfiles/vundle
+++ b/dotfiles/vundle
@@ -7,3 +7,4 @@ Plugin 'tpope/vim-surround'   " deal with (),<>, etc
 Plugin 'tpope/vim-fugitive'   " so much Git integration
 Plugin 'tpope/vim-commentary' " easily comment lines/blocks
 Plugin 'tpope/vim-rails'      " so many Rails helpers
+Plugin 'tpope/vim-markdown'   " markdown highlighting and such


### PR DESCRIPTION
This adds Tim Pope's [Markdown](https://github.com/tpope/vim-markdown) plugin which makes it more convenient working with Markdown files in Vim. This is especially helpful with static site generators and, specifically, our ported website. 