### PR TITLE
Add useful aliases

### DIFF
--- a/dotfiles/bashrc
+++ b/dotfiles/bashrc
@@ -18,6 +18,8 @@ _source_if_exists() {
 alias be='bundle exec'
 alias v='vim'
 alias g='git'
+alias gst='git status'
+alias gap='git add -p'
 
 # attach to the tmux session or create a new named after the user
 alias t='tmux attach-session -t "$(whoami)" || tmux new-session -s "$(whoami)"'
@@ -28,6 +30,7 @@ alias vundle='vim +PluginInstall! +qall'
 # override common tools with useful arguments
 alias grep='grep --color'
 alias ls='ls -FG'
+alias la='ls -lah'
 
 
 

--- a/dotfiles/bashrc
+++ b/dotfiles/bashrc
@@ -15,6 +15,7 @@ _source_if_exists() {
 # ALIASES =====================================================================
 
 # shortcuts for the most commonly used tools
+alias pgup='pg_ctl -D /usr/local/var/postgres -l /usr/local/var/postgres/server.log start'
 alias be='bundle exec'
 alias v='vim'
 alias g='git'

--- a/dotfiles/gitconfig
+++ b/dotfiles/gitconfig
@@ -30,7 +30,7 @@
 
 [alias]
   # commit-specific aliases
-  ci     = commit
+  ci     = commit --verbose
   amend  = commit --amend --reuse-message=HEAD
   reauth = commit --amend --reset-author --reuse-message=HEAD
 


### PR DESCRIPTION
- `git commit --verbose` adds more information to commit screen, including the diff of what is being committed.