### PR TITLE
Git autocomplete when aliased

### DIFF
--- a/dotfiles/bashrc
+++ b/dotfiles/bashrc
@@ -59,6 +59,9 @@ alias vundle='vim +PluginInstall! +qall'
 
 # AUTO-COMPLETES ==============================================================
 
+# use git autocompletion when git is aliased to g
+__git_complete g __git_main
+
 # source any homebrew-supplied autocompletion files
 comps_dir='/usr/local/etc/bash_completion.d'
 


### PR DESCRIPTION
- Now commands starting with `g` should autocomplete commands and branch names the same as commands starting with `git`.
- Addresses issue #4.