### PR TITLE
Vim-endwise completes ruby blocks with `end`

### DIFF
--- a/dotfiles/vundle
+++ b/dotfiles/vundle
@@ -7,3 +7,4 @@ Plugin 'tpope/vim-surround'   " deal with (),<>, etc
 Plugin 'tpope/vim-fugitive'   " so much Git integration
 Plugin 'tpope/vim-commentary' " easily comment lines/blocks
 Plugin 'tpope/vim-rails'      " so many Rails helpers
+Plugin 'tpope/vim-endwise'    " block endings for several languages


### PR DESCRIPTION
- it adds block endings for other languages too
- @kliph doesn't like to type `end`