### PR TITLE
fix bash completion errors / #19

### DIFF
--- a/dotfiles/bashrc
+++ b/dotfiles/bashrc
@@ -73,12 +73,10 @@ take() {
 # AUTO-COMPLETES ==============================================================
 
 # source any homebrew-supplied autocompletion files
-comps_dir='/usr/local/etc/bash_completion.d'
+comps_file='/usr/local/etc/bash_completion'
 
-if [ -d $comps_dir ]; then
-  for file in $(command ls $comps_dir); do
-    . "$comps_dir/$file"
-  done
+if [ -f $comps_file ]; then
+  . $comps_file
 fi
 
 # use git autocompletion when "git" is aliased to "g"


### PR DESCRIPTION
I noticed [these instructions][1] for installing bash completion had you source a file rather than all files in a  directory. Making the change in this pr got rid of the errors from #19 for me, and seem to left bash completion intact.

[1]: https://github.com/bobthecow/git-flow-completion/wiki/Install-Bash-git-completion#homebrew