### PR TITLE
"git checkout" via grep rather than full branch name

### DIFF
--- a/dotfiles/gitconfig
+++ b/dotfiles/gitconfig
@@ -37,6 +37,7 @@
   # checkout-specific aliases
   co     = checkout
   cp     = checkout --patch
+  go     = !sh -c '[[ "$(git branch | grep -i $1 | wc -l)" -eq "1" ]] && git checkout "$(git branch | grep -i $1 | tr -d [:space:])" || echo "\\\"$1\\\" matches zero or multiple branches"' -
 
   # merging
   me     = merge


### PR DESCRIPTION
Hopping around feature branches can be a real pain, especially when following
conventions such as prefixing branch names with ticket numbers. This allows you
to checkout a branch via a grep phrase rather than a full branch name. If the
phrase matches zero or multiple branches, nothing is checked-out and a warning
is printed.