### PR TITLE
Set autocrlf to input

### DIFF
--- a/dotfiles/gitconfig
+++ b/dotfiles/gitconfig
@@ -6,6 +6,7 @@
   ignorecase = false
   precomposeunicode = false
   excludesfile = ~/.gitignore
+  autocrlf = input
 
 [color]
   diff = auto


### PR DESCRIPTION
It showed up in my gitconfig and GitHub recommends this settings...

https://help.github.com/articles/dealing-with-line-endings/