### PR TITLE
Get rid of RVM path warning

### DIFF
--- a/dotfiles/bashrc
+++ b/dotfiles/bashrc
@@ -18,8 +18,8 @@ _source_if_exists() {
 export PATH='/usr/local/bin:/usr/local/sbin:/usr/bin:/usr/sbin:/bin:/sbin'
 
 # additional paths
-export PATH="$PATH:$HOME/.rvm/bin"    # append RVM bins
 export PATH="$HOME/.buffet/bin:$PATH" # prepend Bendyworks bins
+export PATH="$HOME/.rvm/bin:$PATH"    # prepend RVM bins
 
 # set the default editor to Vim
 export EDITOR=vim


### PR DESCRIPTION
> Warning! PATH is not properly set up, '/Users/abraham/.rvm/gems/ruby-2.3.1/bin' is not at first place,
>         usually this is caused by shell initialization files - check them for 'PATH=...' entries,
>         it might also help to re-add RVM to your dotfiles: 'rvm get stable --auto-dotfiles',
>         to fix temporarily in this shell session run: 'rvm use ruby-2.3.1'.