### PR TITLE
Add psack

### DIFF
--- a/dotfiles/bashrc
+++ b/dotfiles/bashrc
@@ -51,6 +51,7 @@ alias r='rake'
 alias grep='grep --color'
 alias ls='ls -FG'
 alias la='ls -lah'
+alias psack='ps aux | grep'
 
 # Git aliases adopted by seemingly every dev shop
 alias gst='git status'


### PR DESCRIPTION
It's called "psack" though it actually uses `grep`, since `ack` would be a dependency. I like `psack` better than `psgrep`