### PR TITLE
Change tmux leader key, set tab titles to session title

### DIFF
--- a/dotfiles/tmux.conf
+++ b/dotfiles/tmux.conf
@@ -1,8 +1,9 @@
 set -g xterm-keys on
 
-# Set prefix key to Ctrl-\
+# Set prefix key to Ctrl-a
 unbind-key C-b
-set-option -g prefix C-'\'
+set-option -g prefix C-a
+bind-key C-a send-prefix
 
 # scrollback buffer n lines
 set -g history-limit 100000
@@ -15,6 +16,10 @@ set -g visual-bell on
 set -g default-terminal "screen-256color" # assume 256 colors
 set -g base-index 1                       # start counting windows at 1
 set -g pane-base-index 1                  # start counting panes at 1
+
+# tab titles
+set-option -g set-titles on
+set-option -g set-titles-string '#S'
 
 # allow mouse usage in tmux
 set -g mouse on


### PR DESCRIPTION
- Switch to using the more common `ctrl-a` prefix key
- in terminals with tabs, set the tab title to the tmux session title