### PR TITLE
Add JetBrains .idea folder to gitignore

### DIFF
--- a/dotfiles/gitignore
+++ b/dotfiles/gitignore
@@ -16,3 +16,6 @@ Thumbs.db
 
 # Compiled C++ files
 *.out
+
+# JetBrains IDE project data
+.idea


### PR DESCRIPTION
RubyMine (and I think other JetBrains IDEs) store project settings in /.idea, and in some shops that might be useful if everyone was using it but it's pollution otherwise.