### PR TITLE
Add global rubocop config

### DIFF
--- a/bin/deploy
+++ b/bin/deploy
@@ -40,6 +40,7 @@ if [ ! -d "$vundle_path" ]; then
   vim +PluginInstall +qall
 fi
 
+# TODO: these take a long time. maybe it'd be better to only install a core set?
 if hash apm 2>/dev/null; then
   echo '-- install Atom plugins...'
   apm install linter merge-conflicts script vim-mode-plus vim-surround atom-pair \

--- a/dotfiles/rubocop.yml
+++ b/dotfiles/rubocop.yml
@@ -12,76 +12,104 @@ AllCops:
 Rails:
   Enabled: true
 
-Style/ConditionalAssignment:
-  EnforcedStyle: assign_inside_condition
-  IncludeTernaryExpressions: false
-
-Style/Documentation:
-  Enabled: false
-
-Style/DocumentationMethod:
-  RequireForNonPublicMethods: false
-
-Style/FrozenStringLiteralComment:
-  EnforcedStyle: never
-
-Style/StringLiterals:
-  EnforcedStyle: single_quotes
-
-# Don't restrict class length too heavily, but don't let it get ridiculous
-Metrics/ClassLength:
-  Max: 1500
-
-# Don't restrict module length too heavily, but don't let it get ridiculous
-Metrics/ModuleLength:
-  Max: 1500
-
-# Good Ruby style says that methods should be short,
-# but being overly restrictive encourages too much indirection
-Metrics/MethodLength:
-  Enabled: true
-  Max: 30
-
-# Too restrictive to leave in by default
-Metrics/AbcSize:
-  Enabled: false
-
-Metrics/PerceivedComplexity:
-  Enabled: True
-  Max: 10
-
+#
+# --- Highly Standard Settings ---
+#
 
 Metrics/LineLength:
   Max: 120
 
+# Documentation is important but shouldn't cause rubocop to fail unless we're working on (eg) a gem
+Style/Documentation:
+  Enabled: false
+
+# Documentation is important but shouldn't cause rubocop to fail unless we're working on (eg) a gem
+Style/DocumentationMethod:
+  RequireForNonPublicMethods: false
+
+# Class size should mainly be limited by SRP, but we can prevent it from getting excessive
+Metrics/ClassLength:
+  Max: 1500
+
+# Module size should mainly be limited by SRP, but we can prevent it from getting excessive
+Metrics/ModuleLength:
+  Max: 1500
+
+#
+# --- Opinionated Settings ---
+#
+
+Style/ConditionalAssignment:
+  EnforcedStyle: assign_inside_condition
+  IncludeTernaryExpressions: false
+
+# If running Ruby 2.3+ we should almost always do this
+# (note that this cop works with the --auto-correct flag)
+Style/FrozenStringLiteralComment:
+  EnforcedStyle: when_needed
+
+# We don't really care about speed that much, but single quotes are cleaner
+# *and* make it clear when a string can contain dynamic components
+Style/StringLiterals:
+  EnforcedStyle: single_quotes
+
+# Good Ruby style says that methods should be short, but being overly restrictive encourages too much indirection.
+# Still, it would be a good idea to tune this down for a greenfield project
+Metrics/MethodLength:
+  Enabled: true
+  Max: 30
+
+# Skip ABC checks since we're using PC and cyclomatic complexity
+Metrics/AbcSize:
+  Enabled: false
+
+# Restrict PC, but not too much
+Metrics/PerceivedComplexity:
+  Enabled: True
+  Max: 10
+
+# If your method has more than 5 params, it should probably be refactored
 Metrics/ParameterLists:
   Enabled: true
+  Max: 5
   CountKeywordArgs: false
 
+# Helps keep Gemfiles organized
+Bundler/OrderedGems:
+  Enabled: true
+  TreatCommentsAsGroupSeparators: true
+
+# Guard clauses make for cleaner code
 Style/GuardClause:
   Enabled: true
 
-Style/EmptyMethod:
-  EnforcedStyle: expanded
-
+# Array sigils are nice but should not be required (or prevented)
 Style/SymbolArray:
   Enabled: false
 
+# Array sigils are nice but should not be required (or prevented)
 Style/WordArray:
   Enabled: false
 
-Performance/Casecmp:
-  Enabled: false
-
-Style/ClassAndModuleChildren:
-  Enabled: false
-
+# Help prevent tricky exception hierarchy-related issues
 Style/RescueStandardError:
   Enabled: true
   EnforcedStyle: implicit
 
+# Compressed empty methods are un-idiomatic (and rare)
+Style/EmptyMethod:
+  EnforcedStyle: expanded
+
+# Class hierarchy varies from project to project
+# (but you should be consistent if possible)
+Style/ClassAndModuleChildren:
+  Enabled: false
+
+# Nobody uses string formatting tokens anyway
 Style/FormatStringToken:
   Enabled: false
 
-Bundler/OrderedGems:
+# Regular case comparison functions are more idiomatic
+# (though this should be enabled in a performance critical project)
+Performance/Casecmp:
   Enabled: false

--- a/dotfiles/rubocop.yml
+++ b/dotfiles/rubocop.yml
@@ -80,7 +80,7 @@ Style/RescueStandardError:
   Enabled: true
   EnforcedStyle: implicit
 
-Style/FormatStringToken: # TODO: remove
+Style/FormatStringToken:
   Enabled: false
 
 Bundler/OrderedGems:

--- a/dotfiles/rubocop.yml
+++ b/dotfiles/rubocop.yml
@@ -1,0 +1,83 @@
+AllCops:
+  TargetRubyVersion: 2.5.1
+  Exclude:
+    - 'db/**/*'
+    - 'config/**/*'
+    - 'bin/**/*'
+    - 'node_modules/**/*'
+    - 'vendor/**/*'
+    - 'lib/**/*' # TODO: Remove
+    - 'script/**/*' # TODO: Remove
+    - 'spec/**/*' # TODO: Remove
+    - 'features/**/*' # TODO: Remove
+    - 'app/controllers/testing/**/*' # TODO: Remove
+
+Rails:
+  Enabled: true
+
+Style/ConditionalAssignment:
+  EnforcedStyle: assign_inside_condition
+  IncludeTernaryExpressions: false
+
+Style/Documentation:
+  Enabled: false
+
+Style/DocumentationMethod:
+  RequireForNonPublicMethods: false
+
+Style/FrozenStringLiteralComment:
+  EnforcedStyle: never
+
+Style/StringLiterals:
+  EnforcedStyle: single_quotes
+
+Metrics/BlockLength: # TODO: remove
+  Enabled: false
+
+Metrics/ClassLength: # TODO: remove?
+  Enabled: false
+
+Metrics/MethodLength: # TODO: remove
+  Enabled: false
+
+Metrics/AbcSize: # TODO: remove
+  Enabled: false
+
+Metrics/CyclomaticComplexity: # TODO: remove
+  Enabled: false
+
+Metrics/PerceivedComplexity: # TODO: remove
+  Enabled: false
+
+Metrics/ModuleLength: # TODO: remove
+  Enabled: false
+
+Metrics/LineLength:
+  Max: 120
+
+Metrics/ParameterLists:
+  Enabled: false
+
+Style/GuardClause:
+  Enabled: false
+
+Style/EmptyMethod:
+  EnforcedStyle: expanded
+
+Performance/Casecmp:
+  Enabled: false
+
+Style/ClassAndModuleChildren:
+  Enabled: false
+
+Style/RescueStandardError: # TODO: remove
+  Enabled: false
+
+Lint/LiteralInInterpolation: # TODO: remove
+  Enabled: false
+
+Style/FormatStringToken: # TODO: remove
+  Enabled: false
+
+Bundler/OrderedGems:
+  Enabled: false

--- a/dotfiles/rubocop.yml
+++ b/dotfiles/rubocop.yml
@@ -1,6 +1,6 @@
 AllCops:
   DisplayStyleGuide: true
-  TargetRubyVersion: 2.5.1 # overriden by .ruby-version
+  TargetRubyVersion: 2.5 # overriden by .ruby-version
   Exclude:
     - 'db/**/*'
     - 'config/**/*'

--- a/dotfiles/rubocop.yml
+++ b/dotfiles/rubocop.yml
@@ -1,16 +1,12 @@
 AllCops:
-  TargetRubyVersion: 2.5.1
+  TargetRubyVersion: 2.5.1 # overriden by .ruby-version
   Exclude:
     - 'db/**/*'
     - 'config/**/*'
     - 'bin/**/*'
     - 'node_modules/**/*'
     - 'vendor/**/*'
-    - 'lib/**/*' # TODO: Remove
-    - 'script/**/*' # TODO: Remove
-    - 'spec/**/*' # TODO: Remove
-    - 'features/**/*' # TODO: Remove
-    - 'app/controllers/testing/**/*' # TODO: Remove
+    - 'script/**/*'
 
 Rails:
   Enabled: true
@@ -63,6 +59,12 @@ Style/GuardClause:
 
 Style/EmptyMethod:
   EnforcedStyle: expanded
+
+Style/SymbolArray:
+  Enabled: false
+
+Style/WordArray:
+  Enabled: false
 
 Performance/Casecmp:
   Enabled: false

--- a/dotfiles/rubocop.yml
+++ b/dotfiles/rubocop.yml
@@ -36,9 +36,11 @@ Metrics/ClassLength:
 Metrics/ModuleLength:
   Max: 1500
 
+# Good Ruby style says that methods should be short,
+# but being overly restrictive encourages too much indirection
 Metrics/MethodLength:
   Enabled: true
-  Max: 20
+  Max: 30
 
 # Too restrictive to leave in by default
 Metrics/AbcSize:

--- a/dotfiles/rubocop.yml
+++ b/dotfiles/rubocop.yml
@@ -28,8 +28,13 @@ Style/FrozenStringLiteralComment:
 Style/StringLiterals:
   EnforcedStyle: single_quotes
 
+# Don't restrict class length too heavily, but don't let it get ridiculous
 Metrics/ClassLength:
-  Enabled: false
+  Max: 1500
+
+# Don't restrict module length too heavily, but don't let it get ridiculous
+Metrics/ModuleLength:
+  Max: 1500
 
 Metrics/MethodLength:
   Enabled: true
@@ -43,8 +48,6 @@ Metrics/PerceivedComplexity:
   Enabled: True
   Max: 10
 
-Metrics/ModuleLength:
-  Enabled: false
 
 Metrics/LineLength:
   Max: 120

--- a/dotfiles/rubocop.yml
+++ b/dotfiles/rubocop.yml
@@ -27,19 +27,15 @@ Style/FrozenStringLiteralComment:
 Style/StringLiterals:
   EnforcedStyle: single_quotes
 
-Metrics/BlockLength: # TODO: remove
+Metrics/ClassLength:
   Enabled: false
 
-Metrics/ClassLength: # TODO: remove?
-  Enabled: false
+Metrics/MethodLength:
+  Enabled: true
+  Max: 20
 
-Metrics/MethodLength: # TODO: remove
-  Enabled: false
-
-Metrics/AbcSize: # TODO: remove
-  Enabled: false
-
-Metrics/CyclomaticComplexity: # TODO: remove
+# Too restrictive to leave in by default
+Metrics/AbcSize:
   Enabled: false
 
 Metrics/PerceivedComplexity: # TODO: remove

--- a/dotfiles/rubocop.yml
+++ b/dotfiles/rubocop.yml
@@ -1,4 +1,5 @@
 AllCops:
+  DisplayStyleGuide: true
   TargetRubyVersion: 2.5.1 # overriden by .ruby-version
   Exclude:
     - 'db/**/*'

--- a/dotfiles/rubocop.yml
+++ b/dotfiles/rubocop.yml
@@ -38,20 +38,22 @@ Metrics/MethodLength:
 Metrics/AbcSize:
   Enabled: false
 
-Metrics/PerceivedComplexity: # TODO: remove
-  Enabled: false
+Metrics/PerceivedComplexity:
+  Enabled: True
+  Max: 10
 
-Metrics/ModuleLength: # TODO: remove
+Metrics/ModuleLength:
   Enabled: false
 
 Metrics/LineLength:
   Max: 120
 
 Metrics/ParameterLists:
-  Enabled: false
+  Enabled: true
+  CountKeywordArgs: false
 
 Style/GuardClause:
-  Enabled: false
+  Enabled: true
 
 Style/EmptyMethod:
   EnforcedStyle: expanded
@@ -68,11 +70,9 @@ Performance/Casecmp:
 Style/ClassAndModuleChildren:
   Enabled: false
 
-Style/RescueStandardError: # TODO: remove
-  Enabled: false
-
-Lint/LiteralInInterpolation: # TODO: remove
-  Enabled: false
+Style/RescueStandardError:
+  Enabled: true
+  EnforcedStyle: implicit
 
 Style/FormatStringToken: # TODO: remove
   Enabled: false


### PR DESCRIPTION
We should standardize on a default set of rubocop rules. This one is extracted from a recent project, but could be modified over time