### PR TITLE
WSL Related Fixes

### DIFF
--- a/bin/deploy
+++ b/bin/deploy
@@ -3,101 +3,11 @@
 set -u
 echo '-- serving Bendyworks Buffet...'
 
-# DOTFILE LINKING =============================================================
+curr_dir="$(dirname "$0")"
 
-# absolute path to the Buffet directory
-rel_path="$(dirname "$0")"
-cd "$rel_path/.."
-export BUFFET_DIRECTORY="$(pwd)"
-
-function contains() {
-  local n=$#
-  local value=${!n}
-  for ((i=1;i < $#;i++)) {
-    if [ "${!i}" == "${value}" ]; then
-      echo "y"
-      return 0
-    fi
-  }
-  echo "n"
-  return 1
-}
-
-# sourcefiles and directories to ignore
-IGNORE_FILES=("." ".." ".git")
-
-# link every dotfile in dotfiles/ into the user's home directory
-# if a dotfile exists with that name, add the ".unused" extension
-for sourcefile in $BUFFET_DIRECTORY/dotfiles/{.*,*}; do
-  filename="${sourcefile##*/}"
-
-  # Ignore certain files
-  if [ $(contains "${IGNORE_FILES[@]}" "$filename") == "y" ]; then
-    continue;
-  fi
-
-  targetfile="$HOME/.$filename"
-
-  [ ! -h "$targetfile" ] && mv "$targetfile" "$targetfile.unused" 2> /dev/null
-
-  if [ -h "$targetfile" ] && [ -d "$targetfile" ]; then
-    echo "removing symlink: $targetfile"
-    rm $targetfile
-  fi
-
-  ln -fs "$sourcefile" "$targetfile"
-done
-
-# VIM SETUP ===================================================================
-
-# set backup directories so that .swp files don't litter the workspace
-vim_dir="$HOME/.vim"
-mkdir -p "$vim_dir/backup"
-mkdir -p "$vim_dir/swp"
-mkdir -p "$vim_dir/undo"
-
-# install vundle to ease installing Vim plugins
-vundle_dir="$vim_dir/bundle"
-vundle_path="$vundle_dir/Vundle.vim"
-vundle_repo='https://github.com/VundleVim/Vundle.vim.git'
-
-mkdir -p "$vundle_dir"
-if [ ! -d "$vundle_path" ]; then
-  echo '-- installing Vim plugins...'
-  git clone "$vundle_repo" "$vundle_path"
-  vim +PluginInstall +qall
-fi
-
-read -p "Install Atom Plugins (Y/n)? " answer
-[ -z "$answer" ] && answer="Y"
-
-if [ "$answer" != "${answer#[Yy]}" ] && hash apm 2>/dev/null; then
-  echo '-- getting list of Atom packages to install...'
-  export PACKAGES_TO_INSTALL=$(./bin/get_apm_packages_to_install)
-
-  if [ -z "$PACKAGES_TO_INSTALL" ]; then
-    echo "-- no Atom packages to install"
-  else
-    echo "-- installing Atom packages: ${PACKAGES_TO_INSTALL}"
-    apm install $PACKAGES_TO_INSTALL
-  fi
-
-  # defaults to NO
-  read -p "Install Vim Mode for Atom (y/N)? " answer
-  if [[ $answer =~ ^[Yy]$ ]]; then
-    apm install \
-      vim-mode-plus \
-      vim-surround
-  fi
-
-  # defaults to NO
-  read -p "Install Emacs Keybindings for Atom (y/N)? " answer
-  if [[ $answer =~ ^[Yy]$ ]]; then
-    apm install atomic-emacs
-  fi
-fi
-
-# CLOSE UP SHOP ===============================================================
+source "$curr_dir/setup_dotfiles"
+source "$curr_dir/setup_vim"
+source "$curr_dir/setup_atom"
 
 echo '-- your buffet has been served!'
 set +u

--- a/bin/setup_atom
+++ b/bin/setup_atom
@@ -1,0 +1,30 @@
+#!/usr/bin/env bash
+
+read -p "Install Atom Plugins (Y/n)? " answer
+[ -z "$answer" ] && answer="Y"
+
+if [ "$answer" != "${answer#[Yy]}" ] && hash apm 2>/dev/null; then
+  echo '-- getting list of Atom packages to install...'
+  export PACKAGES_TO_INSTALL=$(./bin/get_apm_packages_to_install)
+
+  if [ -z "$PACKAGES_TO_INSTALL" ]; then
+    echo "-- no Atom packages to install"
+  else
+    echo "-- installing Atom packages: ${PACKAGES_TO_INSTALL}"
+    apm install $PACKAGES_TO_INSTALL
+  fi
+
+  # defaults to NO
+  read -p "Install Vim Mode for Atom (y/N)? " answer
+  if [[ $answer =~ ^[Yy]$ ]]; then
+    apm install \
+      vim-mode-plus \
+      vim-surround
+  fi
+
+  # defaults to NO
+  read -p "Install Emacs Keybindings for Atom (y/N)? " answer
+  if [[ $answer =~ ^[Yy]$ ]]; then
+    apm install atomic-emacs
+  fi
+fi

--- a/bin/setup_dotfiles
+++ b/bin/setup_dotfiles
@@ -1,0 +1,46 @@
+#!/usr/bin/env bash
+
+# DOTFILE LINKING =============================================================
+
+# absolute path to the Buffet directory
+rel_path="$(dirname "$0")"
+cd "$rel_path/.."
+export BUFFET_DIRECTORY="$(pwd)"
+
+function contains() {
+  local n=$#
+  local value=${!n}
+  for ((i=1;i < $#;i++)) {
+    if [ "${!i}" == "${value}" ]; then
+      echo "y"
+      return 0
+    fi
+  }
+  echo "n"
+  return 1
+}
+
+# sourcefiles and directories to ignore
+IGNORE_FILES=("." ".." ".git")
+
+# link every dotfile in dotfiles/ into the user's home directory
+# if a dotfile exists with that name, add the ".unused" extension
+for sourcefile in $BUFFET_DIRECTORY/dotfiles/{.*,*}; do
+  filename="${sourcefile##*/}"
+
+  # Ignore certain files
+  if [ $(contains "${IGNORE_FILES[@]}" "$filename") == "y" ]; then
+    continue;
+  fi
+
+  targetfile="$HOME/.$filename"
+
+  [ ! -h "$targetfile" ] && mv "$targetfile" "$targetfile.unused" 2> /dev/null
+
+  if [ -h "$targetfile" ] && [ -d "$targetfile" ]; then
+    echo "removing symlink: $targetfile"
+    rm $targetfile
+  fi
+
+  ln -fs "$sourcefile" "$targetfile"
+done

--- a/bin/setup_vim
+++ b/bin/setup_vim
@@ -1,0 +1,24 @@
+#!/usr/bin/env bash
+
+# VIM SETUP ===================================================================
+
+read -p "Setup vim (Y/n)? " answer
+if [[ $answer != ^[Yy]$ ]]; then
+  # set backup directories so that .swp files don't litter the workspace
+  vim_dir="$HOME/.vim"
+  mkdir -p "$vim_dir/backup"
+  mkdir -p "$vim_dir/swp"
+  mkdir -p "$vim_dir/undo"
+
+  # install vundle to ease installing Vim plugins
+  vundle_dir="$vim_dir/bundle"
+  vundle_path="$vundle_dir/Vundle.vim"
+  vundle_repo='https://github.com/VundleVim/Vundle.vim.git'
+
+  mkdir -p "$vundle_dir"
+  if [ ! -d "$vundle_path" ]; then
+    echo '-- installing Vim plugins...'
+    git clone "$vundle_repo" "$vundle_path"
+    vim +PluginInstall +qall
+  fi
+fi

--- a/dotfiles/bashrc
+++ b/dotfiles/bashrc
@@ -19,6 +19,10 @@ source_if_exists "$HOME/.buffet/functions"     # helper functions
 
 [[ `uname -s` == "Darwin" ]] && source_if_exists "$HOME/.buffet/osx"
 
+if grep -q Microsoft /proc/version; then
+  source_if_exists "$HOME/.buffet/windows"
+fi
+
 source_if_exists "$HOME/.buffet/aliases"       # configure command aliases
 source_if_exists "$HOME/.buffet/auto-complete" # configure auto-completion utilities
 source_if_exists "$HOME/.pair"                 # "pair() shell function to set Git pairs"

--- a/dotfiles/bashrc
+++ b/dotfiles/bashrc
@@ -26,4 +26,4 @@ source_if_exists "$HOME/.bashrc.local"         # local .bashrc overrides
 source_if_exists "$HOME/.prompt"               # Bash prompt
 
 # EOF =========================================================================
-if [ -f $(brew --prefix)/etc/bash_completion ]; then source $(brew --prefix)/etc/bash_completion; fi
+if which brew && [ -f $(brew --prefix)/etc/bash_completion ]; then source $(brew --prefix)/etc/bash_completion; fi

--- a/dotfiles/buffet/aliases
+++ b/dotfiles/buffet/aliases
@@ -9,12 +9,13 @@ fi
 
 # GENERAL SHELL ====================================================================================
 
-# Reload the shell (i.e. invoke as a login shell)
-alias reload="exec ${SHELL} -l"
+alias reload="source ~/.bash_profile"
+
 # output path entries on separate lines
 alias path='echo $PATH | tr -s ":" "\n"'
+
 # export each item in a .env file
-alias read_env='export $(grep -v "^#" .env | xargs -0)'
+alias readenv='export $(grep -v "^#" .env | xargs -0)'
 
 alias now='date +"%T"'
 alias nowdate='date +"%d-%m-%Y"'

--- a/dotfiles/buffet/path
+++ b/dotfiles/buffet/path
@@ -1,12 +1,30 @@
 #!/usr/bin/env bash
 
-append_to_path() { if [ -d $1 ]; then export PATH="$PATH:$1"; fi; }
-prepend_to_path() { if [ -d $1 ]; then export PATH="$1:$PATH"; fi; }
-resolve_and_append_to_path() { if [ -d $1 ]; then dir=$(cd $1; pwd); export PATH="$PATH:$dir"; fi; }
-resolve_and_prepend_to_path() { if [ -d $1 ]; then dir=$(cd $1; pwd); export PATH="$dir:$PATH"; fi; }
+append_to_path() {
+  if [[ (-d $1) && (":$PATH:" != *":$1:"*) ]]; then
+    export PATH="$PATH:$1"
+  fi
+}
 
-# normalize the PATH stack
-export PATH='/usr/local/bin:/usr/local/sbin:/usr/bin:/usr/sbin:/bin:/sbin'
+prepend_to_path() {
+  if [[ (-d $1) && (":$PATH:" != *":$1:"*) ]]; then
+    export PATH="$1:$PATH"
+  fi
+}
+
+resolve_and_append_to_path() {
+  if [[ (-d $1) && (":$PATH:" != *":$1:"*) ]]; then
+    dir=$(cd $1; pwd)
+    export PATH="$PATH:$dir"
+  fi
+}
+
+resolve_and_prepend_to_path() {
+  if [[ (-d $1) && (":$PATH:" != *":$1:"*) ]]; then
+    dir=$(cd $1; pwd)
+    export PATH="$dir:$PATH"
+  fi;
+}
 
 # Buffet bins
 prepend_to_path "$HOME/.buffet/bin"

--- a/dotfiles/buffet/windows
+++ b/dotfiles/buffet/windows
@@ -1,0 +1,6 @@
+#!/usr/bin/env bash
+
+{
+  WINDOWS_USER=$(/mnt/c/Windows/System32/cmd.exe /c 'echo %USERNAME%' | sed -e 's/\r//g')
+} &> /dev/null
+export WINHOME="/mnt/c/Users/$WINDOWS_USER"


### PR DESCRIPTION
Fixes related to WSL (Windows Subsystem for Linux)

* remove normalization of PATH
  * In Mac OS, this negates any paths setup by `/etc/path.d/*` or `/etc/path`
  * In WSL, this negates paths related to Windows and Windows Apps like VS Code
* modify path functions to append or prepend only if the path is not already in PATH