### PR TITLE
Reflect rubocop-0.78.0 change moving LineLength to Layout

### DIFF
--- a/dotfiles/rubocop.yml
+++ b/dotfiles/rubocop.yml
@@ -6,7 +6,7 @@ AllCops:
 # --- Highly Standard Settings ---
 #
 
-Metrics/LineLength:
+Layout/LineLength:
   Max: 120
 
 # Documentation is important but shouldn't cause rubocop to fail unless we're working on (eg) a gem


### PR DESCRIPTION
Rubocop's 0.78.0 update made a change that moved the `LineLength` cop to `Layout` from `Metrics`, and repositories that use this file directly via `inherit_from` or will use this file later log an error to console to that end when rubocop runs.

This PR updates the config to match the cop change.