### PR TITLE
Update bashrc to use type instead of which

### DIFF
--- a/dotfiles/bashrc
+++ b/dotfiles/bashrc
@@ -30,4 +30,6 @@ source_if_exists "$HOME/.bashrc.local"         # local .bashrc overrides
 source_if_exists "$HOME/.prompt"               # Bash prompt
 
 # EOF =========================================================================
-if which -s brew && [ -f $(brew --prefix)/etc/bash_completion ]; then source $(brew --prefix)/etc/bash_completion; fi
+if type brew &>/dev/null && [ -f $(brew --prefix)/etc/bash_completion ]; then
+ source $(brew --prefix)/etc/bash_completion
+fi


### PR DESCRIPTION
`which` is a zsh builtin and `-s` operates differently than `/usr/bin/which -s`. The zsh version outputs a symlink free pathname instead of silencing output.

I've also changed to using `type` rather than just redirecting output as I see its use in the auto-complete configuration for checking to see if commands exist.